### PR TITLE
lastfix

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,9 +1,6 @@
-# frozen_string_literal: true
+
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
-
 
   def new
     @user = User.new

--- a/app/models/sending_destination.rb
+++ b/app/models/sending_destination.rb
@@ -1,16 +1,12 @@
 class SendingDestination < ApplicationRecord
   belongs_to :user,optional: true
   validates :destination_first_name, :destination_family_name, :destination_first_name_kana, 
-  :destination_family_name_kana, :post_code, :prefecture_name,:City,
+  :destination_family_name_kana, :prefecture_name,:City,
   :address,presence: true
+  validates :post_code, format:{with:/\A\d{7}\z/,message:"は、半角数字で入力してください"}
   validates :destination_first_name, :destination_family_name, format: { with: /[^\x01-\x7E]+/, message: "は、全角で入力してください"}
   validates :destination_first_name_kana, :destination_family_name_kana, format: { with: /[\p{katakana} ー－&&[^ -~｡-ﾟ]]+/, message: "は、全角カタカナで入力してください"}
   include JpPrefecture
   jp_prefecture :prefecture_name
-  # def prefecture_name
-  #   JpPrefecture::Prefecture.find(code: prefecture_name).try(:name)
-  # end
-  # def prefecture_name=(prefecture_name)
-  #   self.prefecture_code = JpPrefecture::Prefecture.find(name: prefecture_name).code
-  # end
+  
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 7..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly


### PR DESCRIPTION
[what]
郵便番号が半角数字のみ許可
パスワードは「７文字以上入力してください」のエラーメッセージが出る
[why]
アプリの機能上必要となるため